### PR TITLE
fix: crush if window.mina is not defined

### DIFF
--- a/apps/web/lib/stores/wallet.tsx
+++ b/apps/web/lib/stores/wallet.tsx
@@ -25,7 +25,7 @@ export interface WalletState {
 export const useWalletStore = create<WalletState, [["zustand/immer", never]]>(
   immer((set) => ({
     async initializeWallet() {
-      if (!mina) {
+      if (typeof mina === 'undefined') {
         throw new Error("Auro wallet not installed");
       }
 
@@ -36,7 +36,7 @@ export const useWalletStore = create<WalletState, [["zustand/immer", never]]>(
       });
     },
     async connectWallet() {
-      if (!mina) {
+      if (typeof mina === 'undefined') {
         throw new Error("Auro wallet not installed");
       }
 
@@ -47,7 +47,7 @@ export const useWalletStore = create<WalletState, [["zustand/immer", never]]>(
       });
     },
     observeWalletChange() {
-      if (!mina) {
+      if (typeof mina === 'undefined') {
         throw new Error("Auro wallet not installed");
       }
 


### PR DESCRIPTION
Now example crushed in case if window.mina is not defined:
<img width="834" alt="image" src="https://github.com/proto-kit/starter-kit/assets/25568730/fab9cd23-3501-45c4-9c8b-8ef1b3cbdf57">

This is because if variable is not defined, this should be checked by `typeof mina === 'undefined' ` not `!mina`: otherwise `ReferenceError` is raised