### PR TITLE
docfix: fix link to official documentation in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Protokit starter-kit
 
 This repository is a monorepo aimed at kickstarting application chain development using the Protokit framework.
-You can learn more about the Protokit framework at the [official documentation](protokit.dev), or at the official [Mina discord](https://discord.gg/minaprotocol).
+You can learn more about the Protokit framework at the [official documentation](https://protokit.dev), or at the official [Mina discord](https://discord.gg/minaprotocol).
 
 ## Quick start
 


### PR DESCRIPTION
The official documentation link in readme.md is not properly hyperlinkedinked in Readme.md

<img width="224" alt="image" src="https://github.com/user-attachments/assets/a9c9fcd3-562c-4326-8e13-1ee309641c1c">


<img width="996" alt="image" src="https://github.com/user-attachments/assets/15e28686-d8e6-48b4-97a8-435311ca2185">
