### PR TITLE
Kadircan/Warn Devs on Missing await

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "trailingComma": "es5",
+  "singleQuote": false,
+  "tabWidth": 2,
+  "useTabs": false,
+  "printWidth": 80
+}

--- a/packages/chain/.eslintrc.cjs
+++ b/packages/chain/.eslintrc.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+    extends: ["custom/library"],
+};

--- a/packages/chain/.eslintrc.js
+++ b/packages/chain/.eslintrc.js
@@ -1,3 +1,0 @@
-module.exports = {
-  extends: ["custom/library"],
-};

--- a/packages/eslint-config-custom/library.js
+++ b/packages/eslint-config-custom/library.js
@@ -12,25 +12,26 @@ const project = resolve(process.cwd(), "tsconfig.json");
  */
 
 module.exports = {
-    extends: ["@vercel/style-guide/eslint/node", "@vercel/style-guide/eslint/typescript"].map(
-        require.resolve
-    ),
-    parserOptions: {
+  extends: [
+    "@vercel/style-guide/eslint/node",
+    "@vercel/style-guide/eslint/typescript",
+  ].map(require.resolve),
+  parserOptions: {
+    project,
+  },
+  globals: {
+    React: true,
+    JSX: true,
+  },
+  settings: {
+    "import/resolver": {
+      typescript: {
         project,
+      },
     },
-    globals: {
-        React: true,
-        JSX: true,
-    },
-    settings: {
-        "import/resolver": {
-            typescript: {
-                project,
-            },
-        },
-    },
-    ignorePatterns: ["node_modules/", "dist/"],
-    rules: {
-        "@typescript-eslint/no-floating-promises": "warn",
-    },
+  },
+  ignorePatterns: ["node_modules/", "dist/"],
+  rules: {
+    "@typescript-eslint/no-floating-promises": "error",
+  },
 };

--- a/packages/eslint-config-custom/library.js
+++ b/packages/eslint-config-custom/library.js
@@ -12,23 +12,25 @@ const project = resolve(process.cwd(), "tsconfig.json");
  */
 
 module.exports = {
-  extends: [
-    "@vercel/style-guide/eslint/node",
-    "@vercel/style-guide/eslint/typescript",
-  ].map(require.resolve),
-  parserOptions: {
-    project,
-  },
-  globals: {
-    React: true,
-    JSX: true,
-  },
-  settings: {
-    "import/resolver": {
-      typescript: {
+    extends: ["@vercel/style-guide/eslint/node", "@vercel/style-guide/eslint/typescript"].map(
+        require.resolve
+    ),
+    parserOptions: {
         project,
-      },
     },
-  },
-  ignorePatterns: ["node_modules/", "dist/"],
+    globals: {
+        React: true,
+        JSX: true,
+    },
+    settings: {
+        "import/resolver": {
+            typescript: {
+                project,
+            },
+        },
+    },
+    ignorePatterns: ["node_modules/", "dist/"],
+    rules: {
+        "@typescript-eslint/no-floating-promises": "warn",
+    },
 };


### PR DESCRIPTION
This PR add floating promise warning to linter for preventing missing awaits in runtime code.
example warning:
<img width="804" height="169" alt="Screenshot 2025-11-05 at 17 44 11" src="https://github.com/user-attachments/assets/9c2b9afe-9b8e-4a75-a195-63a7186c14a4" />


closes to: [#199](https://github.com/proto-kit/framework/issues/199)